### PR TITLE
Initial commit of Hacked version of js-cookie version 3.0.1, with changes for Cordova iOS for WeVote

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,4 @@
-<p align="center">
-  <img src="https://cloud.githubusercontent.com/assets/835857/14581711/ba623018-0436-11e6-8fce-d2ccd4d379c9.gif">
-</p>
-
-# November 3, 2021:  Hacked version of js-cookie version 3.0.1, with changes for Cordova iOS for WeVote
-
+### November 3, 2021:  Hacked version of js-cookie version 3.0.1, with changes for Cordova iOS for WeVote
 
 # JavaScript Cookie [![Build Status](https://travis-ci.com/js-cookie/js-cookie.svg?branch=master)](https://travis-ci.com/js-cookie/js-cookie) [![BrowserStack Status](https://www.browserstack.com/automate/badge.svg?badge_key=b3VDaHAxVDg0NDdCRmtUOWg0SlQzK2NsRVhWTjlDQS9qdGJoak1GMzJiVT0tLVhwZHNvdGRoY284YVRrRnI3eU1JTnc9PQ==--5e88ffb3ca116001d7ef2cfb97a4128ac31174c2)](https://www.browserstack.com/automate/public-build/b3VDaHAxVDg0NDdCRmtUOWg0SlQzK2NsRVhWTjlDQS9qdGJoak1GMzJiVT0tLVhwZHNvdGRoY284YVRrRnI3eU1JTnc9PQ==--5e88ffb3ca116001d7ef2cfb97a4128ac31174c2) [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com) [![Code Climate](https://codeclimate.com/github/js-cookie/js-cookie.svg)](https://codeclimate.com/github/js-cookie/js-cookie) [![npm](https://img.shields.io/github/package-json/v/js-cookie/js-cookie)](https://www.npmjs.com/package/js-cookie) [![size](https://img.shields.io/bundlephobia/minzip/js-cookie/3)](https://www.npmjs.com/package/js-cookie) [![jsDelivr Hits](https://data.jsdelivr.com/v1/package/npm/js-cookie/badge?style=rounded)](https://www.jsdelivr.com/package/npm/js-cookie)
 

--- a/src/api.mjs
+++ b/src/api.mjs
@@ -1,3 +1,4 @@
+// Hacked version of js-cookie version 3.0.1, with changes for Cordova iOS for WeVote
 /* eslint-disable no-var */
 import assign from './assign.mjs'
 import defaultConverter from './converter.mjs'


### PR DESCRIPTION
Works around a problem with Cordova iOS where document.cookie does not accept changes.